### PR TITLE
[VAN-135012] Using new DTO names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,23 +146,22 @@ if api_response.status_code == 200:
 
 # RESTResponseType
 # Use this method to work with raw data.
-from visier_platform_sdk.models.dataservices_datamodel_properties_dto import DataservicesDatamodelPropertiesDTO
+from visier_platform_sdk import PropertiesDTO
 
 rest_response = data_model_api.properties_without_preload_content(analytic_object_id)
 if rest_response.status == 200:
-    properties = DataservicesDatamodelPropertiesDTO.from_json(rest_response.data.decode())
+    properties = PropertiesDTO.from_json(rest_response.data.decode())
 ```
 
 For full API DTO documentation, see the API references. For example, [Visier Data In APIs](https://docs.visier.com/developer/Default.htm#cshid=1042).
 All DTOs have a `from_json` method to create a DTO object from a JSON string. In some cases, you may need to switch from DTO format to CSV format. To switch, set the `Accept` header to `text/csv` when creating the `ApiClient` or making a request.
 
 ```python
-from visier_platform_sdk import ApiClient, DataQueryApi
-from visier_platform_sdk.models.dataservices_query_aggregation_query_execution_dto import DataservicesQueryAggregationQueryExecutionDTO
+from visier_platform_sdk import ApiClient, DataQueryApi, AggregationQueryExecutionDTO
 
 with open('query_examples/aggregate/applicants-source.json') as f:
     headcount_json = f.read()
-aggr_query_dto = DataservicesQueryAggregationQueryExecutionDTO.from_json(headcount_json)
+aggr_query_dto = AggregationQueryExecutionDTO.from_json(headcount_json)
 
 # Set the `Accept` header to `text/csv` in the constructor or by using the `set_default_header` method.
 # The `set_default_header` method allows you to add additional headers as needed.

--- a/tests/integration/test_data_intake_api.py
+++ b/tests/integration/test_data_intake_api.py
@@ -2,8 +2,8 @@ import unittest
 from typing import Type, TypeVar
 
 from test_utils import create_api, TENANT_CODE
-from visier_platform_sdk import DataIntakeApi, DataInStartTransferResponse, DataInPushDataResponse, \
-    DataInPushDataCompleteRequest, DataInPushDataCompleteResponse
+from visier_platform_sdk import DataIntakeApi, StartTransferResponse, PushDataResponse, \
+    PushDataCompleteRequest, PushDataCompleteResponse
 
 from visier_platform_sdk.rest import RESTResponseType
 
@@ -46,22 +46,22 @@ class TestDataIntakeApi(unittest.TestCase):
         self.assertGreater(len(sources_dto.sources), 1)
 
         transfer_rest_response = self.api.start_transfer_without_preload_content()
-        transfer_response_dto = self.get_dto_from_response(transfer_rest_response, DataInStartTransferResponse)
+        transfer_response_dto = self.get_dto_from_response(transfer_rest_response, StartTransferResponse)
         try:
             upload_rest_response = self.api.upload_data_without_preload_content(
                 transfer_session_id=transfer_response_dto.transfer_session_id,
                 source_id=sources_dto.sources[0].source_id,
                 tenant_code=TENANT_CODE,
                 file="data/applicant.csv")
-            push_data_response_dto = self.get_dto_from_response(upload_rest_response, DataInPushDataResponse)
+            push_data_response_dto = self.get_dto_from_response(upload_rest_response, PushDataResponse)
             self.assertEqual('SUCCEED', push_data_response_dto.status)
 
-            push_data_completed = DataInPushDataCompleteRequest(
+            push_data_completed = PushDataCompleteRequest(
                 transfer_session_id=transfer_response_dto.transfer_session_id,
             )
             push_complete_rest_response = self.api.push_data_complete_without_preload_content(push_data_completed)
             push_complete_response = self.get_dto_from_response(push_complete_rest_response,
-                                                                DataInPushDataCompleteResponse)
+                                                                PushDataCompleteResponse)
             self.assertIsNotNone(push_complete_response)
 
         except Exception as e:

--- a/tests/integration/test_data_query_api.py
+++ b/tests/integration/test_data_query_api.py
@@ -2,9 +2,9 @@ import os
 import unittest
 
 from test_utils import create_api
-from visier_platform_sdk import DataQueryApi, DataservicesQueryListQueryExecutionDTO, \
-    DataservicesQueryAggregationQueryExecutionDTO, \
-    DataservicesQuerySnapshotQueryExecutionDTO, DataservicesQuerySqlLikeQueryExecutionDTO, DataservicesQueryCellSetDTO, \
+from visier_platform_sdk import DataQueryApi, ListQueryExecutionDTO, \
+    AggregationQueryExecutionDTO, \
+    SnapshotQueryExecutionDTO, SqlLikeQueryExecutionDTO, CellSetDTO, \
     TableResponseDTO
 
 QUERY_PATH = 'data/queries'
@@ -32,7 +32,7 @@ class TestDataQueryApi(unittest.TestCase):
         """
 
         query_content = get_query_content('aggregate.json')
-        aggregate_query_dto = DataservicesQueryAggregationQueryExecutionDTO.from_json(query_content)
+        aggregate_query_dto = AggregationQueryExecutionDTO.from_json(query_content)
         cell_set_dto = self.api.aggregate(aggregate_query_dto)
 
         self.assertIsNotNone(cell_set_dto)
@@ -46,7 +46,7 @@ class TestDataQueryApi(unittest.TestCase):
         """
 
         query_content = get_query_content('list.json')
-        list_query_dto = DataservicesQueryListQueryExecutionDTO.from_json(query_content)
+        list_query_dto = ListQueryExecutionDTO.from_json(query_content)
         list_response_dto = self.api.list(list_query_dto)
 
         self.assertIsNotNone(list_response_dto)
@@ -59,7 +59,7 @@ class TestDataQueryApi(unittest.TestCase):
         """
 
         query_content = get_query_content('snapshot.json')
-        snapshot_query_dto = DataservicesQuerySnapshotQueryExecutionDTO.from_json(query_content)
+        snapshot_query_dto = SnapshotQueryExecutionDTO.from_json(query_content)
         response_dto = self.api.query_snapshot(snapshot_query_dto)
 
         self.assertIsNotNone(response_dto)
@@ -71,13 +71,13 @@ class TestDataQueryApi(unittest.TestCase):
         Should return CellSetDTO
         """
 
-        sqlike_query_dto = DataservicesQuerySqlLikeQueryExecutionDTO(
+        sqlike_query_dto = SqlLikeQueryExecutionDTO(
             query='SELECT employeeCount() AS "Headcount", Union_Status FROM Employee'
         )
         sqlike_response_dto = self.api.sql_like(sqlike_query_dto)
         self.assertIsNotNone(sqlike_response_dto)
         self.assertIsNotNone(sqlike_response_dto.actual_instance)
-        self.assertIsInstance(sqlike_response_dto.actual_instance, DataservicesQueryCellSetDTO)
+        self.assertIsInstance(sqlike_response_dto.actual_instance, CellSetDTO)
 
     def test_sql_like(self) -> None:
         """Test case for sql_like
@@ -85,7 +85,7 @@ class TestDataQueryApi(unittest.TestCase):
         Should return TableResponseDTO
         """
 
-        sqlike_query_dto = DataservicesQuerySqlLikeQueryExecutionDTO(
+        sqlike_query_dto = SqlLikeQueryExecutionDTO(
             query="SELECT EmployeeID, First_Name, Last_Name FROM Employee WHERE isFemale=TRUE "
                   "AND Visier_Time BETWEEN date('2021-01-01') AND date('2022-01-01')"
         )

--- a/tests/integration/test_production_versions_api.py
+++ b/tests/integration/test_production_versions_api.py
@@ -1,7 +1,7 @@
 import unittest
 
 from test_utils import create_api
-from visier_platform_sdk import ProductionVersionsApi, ServicingProductionVersionAPIOperationRequestDTO
+from visier_platform_sdk import ProductionVersionsApi, ProductionVersionAPIOperationRequestDTO
 
 
 class TestProductionVersionsApi(unittest.TestCase):
@@ -26,7 +26,7 @@ class TestProductionVersionsApi(unittest.TestCase):
         self.assertIsNotNone(versions_response_dto.published_versions)
         self.assertGreater(len(versions_response_dto.published_versions), 1)
 
-        operation_request_dto = ServicingProductionVersionAPIOperationRequestDTO(
+        operation_request_dto = ProductionVersionAPIOperationRequestDTO(
             operation='rollBackTo'
         )
         operation_response_dto = self.api.post_production_version(versions_response_dto.published_versions[1].id,

--- a/tests/integration/test_sources_api.py
+++ b/tests/integration/test_sources_api.py
@@ -3,7 +3,7 @@ import unittest
 import zipfile
 
 from test_utils import create_api
-from visier_platform_sdk import SourcesApi, ServicingSourcesAPIOperationRequestDTO, SourcesAPIPutResponseDTO
+from visier_platform_sdk import SourcesApi, SourcesAPIOperationRequestDTO, SourcesAPIPutResponseDTO
 
 
 class TestSourcesApi(unittest.TestCase):
@@ -16,7 +16,7 @@ class TestSourcesApi(unittest.TestCase):
         pass
 
     def test_get_sources(self) -> None:
-        operation_request_dto = ServicingSourcesAPIOperationRequestDTO(
+        operation_request_dto = SourcesAPIOperationRequestDTO(
             operation='exportSources'
         )
 

--- a/tests/integration/test_users_v1_api.py
+++ b/tests/integration/test_users_v1_api.py
@@ -1,7 +1,7 @@
 import unittest
 
 from test_utils import TENANT_CODE, create_api
-from visier_platform_sdk import UsersV1Api, ServicingUserCreationAPIRequestDTO, UserCreationAPIResponseDTO
+from visier_platform_sdk import UsersV1Api, UserCreationAPIRequestDTO, UserCreationAPIResponseDTO
 
 
 class TestUsersV1Api(unittest.TestCase):
@@ -29,7 +29,7 @@ class TestUsersV1Api(unittest.TestCase):
             api_response = self.api.delete_user_with_http_info(test_user.user_id, tenant_code=TENANT_CODE)
             self.assertEqual(api_response.status_code, 204)
 
-        creation_request_dto = ServicingUserCreationAPIRequestDTO(
+        creation_request_dto = UserCreationAPIRequestDTO(
             account_enabled='true',
             display_name='Creation test User Visier Python SDK',
             email=test_user_email,


### PR DESCRIPTION
### Overview
This PR updates Python SDK integration tests and README.md to use the new shortened DTO class names introduced in the previous PR.

### Changes
- Updated references to renamed DTOs in integration tests
- Updated code examples in README.md to reflect the new naming convention